### PR TITLE
Update HypertextLiteral compatibility version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 AbstractPlutoDingetjes = "1"
 DocStringExtensions = "0.9"
-HypertextLiteral = "0.9"
+HypertextLiteral = "0.9, 1"
 InteractiveUtils = "1"
 Markdown = "1"
 PlutoUI = "0.7.51"


### PR DESCRIPTION
As per https://github.com/JuliaPluto/HypertextLiteral.jl/releases/tag/v1.0.0

> No breaking changes! This marks HypertextLiteral as production ready.
> You can safely update your compatibility from 0.9 to 0.9, 1.